### PR TITLE
Fixes #9 - Support Android Gradle plugin 1.1.0

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,10 +17,10 @@ dependencies {
     gradleApi gradleApi()
     groovy localGroovy()
 
-    compile 'com.android.tools.build:builder-test-api:0.6+'
+    compile 'com.android.tools.build:builder-test-api:1.1.0'
     compile 'com.testdroid:testdroid-api:1.4.8'
     testCompile 'junit:junit:3.8.1'
-    testCompile 'com.android.tools.build:gradle:0.6+'
+    testCompile 'com.android.tools.build:gradle:1.1.0'
 
 }
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -2,4 +2,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=http\://services.gradle.org/distributions/gradle-1.8-bin.zip
+distributionUrl=http\://services.gradle.org/distributions/gradle-2.2-bin.zip


### PR DESCRIPTION
This PR fixes issue #9 where the plugin does not work with the latest Android build tools (v1.1.0).

It updates the Android tooling and Gradle to the latest versions. It also fixes the changes in the API that were introduced with the new Android plugin.